### PR TITLE
Avoid build break

### DIFF
--- a/tests/Monolog/LoggerTest.php
+++ b/tests/Monolog/LoggerTest.php
@@ -553,6 +553,10 @@ class LoggerTest extends \PHPUnit_Framework_TestCase
      */
     public function testUseMicrosecondTimestamps($micro, $assert, $assertFormat)
     {
+        if (PHP_VERSION_ID === 70103) {
+            $this->markTestSkipped();
+        }
+
         $logger = new Logger('foo');
         $logger->useMicrosecondTimestamps($micro);
         $handler = new TestHandler;


### PR DESCRIPTION
Skipping DateTime microsecond test in PHP 7.1.3, because of [PHP bug](https://bugs.php.net/bug.php?id=74258) preventing it from working.